### PR TITLE
Updated lobbies to use their randomised problem set

### DIFF
--- a/event.go
+++ b/event.go
@@ -153,7 +153,8 @@ func StartGameHandler(event Event, c *Client) error {
 	}
 
 	// Send the first problem
-	var newProblemBroadcast = NewProblemEvent{GetProblems().Problems[0]}
+	user := c.lobby.userMapping[c.name]
+	var newProblemBroadcast = NewProblemEvent{GetProblems().Problems[c.lobby.Problems[user.questionNumber]]}
 
 	data, err = json.Marshal(newProblemBroadcast)
 	if err != nil {
@@ -178,7 +179,7 @@ func GiveAnswerHandler(event Event, c *Client) error {
 		return fmt.Errorf("bad payload in request: %v", err)
 	}
 	user := c.lobby.userMapping[c.name]
-	problem := GetProblems().Problems[user.questionNumber]
+	problem := GetProblems().Problems[c.lobby.Problems[user.questionNumber]]
 	if !problem.CheckAnswer(chatevent.Answer) {
 		c.egress <- Event{EventWrongAnswer, nil}
 		return fmt.Errorf("bad payload in request")
@@ -233,7 +234,7 @@ func RequestProblemHandler(event Event, c *Client) error {
 		return nil
 	}
 
-	var newProblemBroadcast = NewProblemEvent{GetProblems().Problems[user.questionNumber]}
+	var newProblemBroadcast = NewProblemEvent{GetProblems().Problems[c.lobby.Problems[user.questionNumber]]}
 
 	data, err := json.Marshal(newProblemBroadcast)
 	if err != nil {

--- a/manager.go
+++ b/manager.go
@@ -131,7 +131,6 @@ func NewLobby(ctx context.Context, name string) *Lobby {
 	for i := 0; i < len(l.Problems); i++ {
 		// Generate x as a random value between 0 and the length of the problems array
 		// and as long as the randomly chosen problem isn't already selected
-		// TODO: needs to be getting a random number from the _size_, not the length to be random
 		x := rand.Intn(len(booleanArray))
 		for booleanArray[x] {
 			x = rand.Intn(len(booleanArray))


### PR DESCRIPTION
Lobbies previously would always have the problem set in order, this has been resolved to use the lobby-specific randomised problem set instead.