### PR TITLE
Made the endGame function return an error when it occurs

### DIFF
--- a/event.go
+++ b/event.go
@@ -115,18 +115,19 @@ func GetProblems() *Problems {
 	return problems
 }
 
-func endGame(c *Client, message string) {
+func endGame(c *Client, message string) error {
 	var broadMessage = EndGameEvent{message}
 
 	data, err := json.Marshal(broadMessage)
 	if err != nil {
-		fmt.Errorf("failed to marshal broadcast message: %v", err)
+		return fmt.Errorf("failed to marshal broadcast message: %v", err)
 	}
 
 	var outgoingEvent = Event{EventEndGame, data}
 	for client := range c.lobby.clients {
 		client.egress <- outgoingEvent
 	}
+	return nil
 }
 
 // EventStartGame is sent when the game is started by the owner


### PR DESCRIPTION
Code previously did not actually throw the error in endGame when it came up - now it does.
![image](https://user-images.githubusercontent.com/105893652/222344110-60cf4ea4-03c9-4ada-bec6-31b4d648a63c.png)
