### PR TITLE
Resolving a Potential Race condition

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -14,21 +14,17 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var (
-	/**
-	websocketUpgrader is used to upgrade incomming HTTP requests into a persistent websocket connection
-	*/
-	websocketUpgrader = websocket.Upgrader{
-		// Apply the Origin Checker
-		CheckOrigin:     checkOrigin,
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-	}
-)
+/**
+websocketUpgrader is used to upgrade incomming HTTP requests into a persistent websocket connection
+*/
+var websocketUpgrader = websocket.Upgrader{
+	// Apply the Origin Checker
+	CheckOrigin:     checkOrigin,
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
 
-var (
-	ErrEventNotSupported = errors.New("this event type is not supported")
-)
+var ErrEventNotSupported = errors.New("this event type is not supported")
 
 var handlers = map[string]EventHandler{
 	EventStartGameOwner: StartGameHandler,
@@ -91,7 +87,7 @@ type Lobby struct {
 	sync.RWMutex
 
 	// otps is a map of allowed OTP to accept connections from
-	otps RetentionMap
+	otps *RetentionMap
 }
 
 // UUID to Lobby map
@@ -160,7 +156,6 @@ func (m *Manager) routeEvent(event Event, c *Client) error {
 
 // loginHandler is used to verify an user authentication and return a one time password
 func (m *Manager) loginHandler(w http.ResponseWriter, r *http.Request) {
-
 	type userLoginRequest struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -233,7 +228,6 @@ func (m *Manager) loginHandler(w http.ResponseWriter, r *http.Request) {
 
 // serveWS is a HTTP Handler that the has the Manager that allows connections
 func (m *Manager) serveWS(w http.ResponseWriter, r *http.Request) {
-
 	// Grab the OTP in the Get param
 	otp := r.URL.Query().Get("otp")
 	if otp == "" {

--- a/otp.go
+++ b/otp.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,58 +12,88 @@ import (
 type OTP struct {
 	Key     string
 	Created time.Time
+
+	used bool
+	sync.Mutex
 }
 
 type Verifier interface {
 	VerifyOTP(otp string) bool
 }
 
-type RetentionMap map[string]OTP
+type RetentionMap struct {
+	retentionMap    map[string]*OTP
+	retentionPeriod time.Duration
+	sync.RWMutex
+}
 
-// NewRetentionMap will create a new retentionmap and start the retention given the set period
-func NewRetentionMap(ctx context.Context, retentionPeriod time.Duration) RetentionMap {
-	rm := make(RetentionMap)
+// NewRetentionMap will create a new retention map and start the retention given the set period
+func NewRetentionMap(ctx context.Context, retentionPeriod time.Duration) *RetentionMap {
+	rm := RetentionMap{
+		retentionMap:    make(map[string]*OTP),
+		retentionPeriod: retentionPeriod,
+	}
 
 	go rm.Retention(ctx, retentionPeriod)
-
-	return rm
+	return &rm
 }
 
 // NewOTP creates and adds a new otp to the map
-func (rm RetentionMap) NewOTP() OTP {
+func (rm *RetentionMap) NewOTP() OTP {
+	rm.Lock()
+	defer rm.Unlock()
+
 	o := OTP{
 		Key:     uuid.NewString(),
 		Created: time.Now(),
 	}
 
-	rm[o.Key] = o
+	rm.retentionMap[o.Key] = &o
+	// copies a lock but its ok because we shouldn't return a referenced to a stored
+	// OTP anyways
 	return o
 }
 
 // VerifyOTP will make sure a OTP exists and return true if so
 // It will also delete the key so it can't be reused
-func (rm RetentionMap) VerifyOTP(otp string) bool {
+func (rm *RetentionMap) VerifyOTP(otp string) bool {
+	rm.RLock()
+	defer rm.RUnlock()
+
 	// Verify OTP is existing
-	if _, ok := rm[otp]; !ok {
-		// otp does not exist
-		return false
+	// check its expiry if it does
+	if referencedOTP, ok := rm.retentionMap[otp]; ok {
+		referencedOTP.Lock()
+		defer referencedOTP.Unlock()
+
+		otpIsExpired := referencedOTP.Created.Add(rm.retentionPeriod).After(time.Now()) || referencedOTP.used
+		if otpIsExpired {
+			return false
+		}
+
+		referencedOTP.used = true
+		return true
 	}
-	delete(rm, otp)
+
+	// otp does not exist
 	return true
 }
 
 // Retention will make sure old OTPs are removed; this is blocking, so run as a Goroutine
-func (rm RetentionMap) Retention(ctx context.Context, retentionPeriod time.Duration) {
-	ticker := time.NewTicker(400 * time.Millisecond)
+func (rm *RetentionMap) Retention(ctx context.Context, retentionPeriod time.Duration) {
+	ticker := time.NewTicker(1000 * time.Millisecond)
+
 	for {
 		select {
 		case <-ticker.C:
-			for _, otp := range rm {
+			rm.Lock()
+			for _, otp := range rm.retentionMap {
 				// Add Retention to Created and check if it is expired
-				if otp.Created.Add(retentionPeriod).Before(time.Now()) {
-					delete(rm, otp.Key)
+				if otp.Created.Add(retentionPeriod).Before(time.Now()) || otp.used {
+					delete(rm.retentionMap, otp.Key)
 				}
 			}
+			rm.Unlock()
 		case <-ctx.Done():
 			return
 		}

--- a/otp_test.go
+++ b/otp_test.go
@@ -25,7 +25,6 @@ func TestRetentionMap_VerifyOTP(t *testing.T) {
 }
 
 func TestOTP_Retention(t *testing.T) {
-
 	// Create context with cancel to stop goroutine
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -41,11 +40,11 @@ func TestOTP_Retention(t *testing.T) {
 	otp := rm.NewOTP()
 
 	// Make sure that only 1 password is still left and it matches the latest
-	if len(rm) != 1 {
+	if len(rm.retentionMap) != 1 {
 		t.Error("Failed to clean up")
 	}
 
-	if rm[otp.Key] != otp {
+	if *rm.retentionMap[otp.Key] != otp {
 		t.Error("The key should still be in place")
 	}
 	cancel()


### PR DESCRIPTION
Resolving a potential race condition + also looks like my linter automatically did some linting.

# The Race Condition
The old OTP code maintained a goroutine that would run every 400ms and delete expired OTPs, there was no lock in place to prevent concurrent writes/reads so this was potentially rather dangerous. Additionally, the `VerifyOTP` function relied to the fact that old OTPs would be purged from the system when they expire, there exists scheduling orders for goroutines where this may not be true :(.

## Changes
 - Modified the `RetentionMap` to maintain a `ReaderWriterMutex`, allows for multiple simultaneous reads but blocks on a write
 - Modified the OTPs to maintain an `isUsed` field to indicate that they have been used, added a lock to prevent concurrent reads + writes to the same OTP
 - Increase the interval in which OTPs are purged in order to decrease lock contention

## Explanation
 - Now the `VerifyOTP` function acquires a reading lock for the RetentionMap prior to verifying an OTP
      - If an OTP is found it acquires the lock to that OTP and verifies if its expired
 - Every 1 second the `Retention` method acquires a write lock and purges expired OTPs