### PR TITLE
chore(readme): use $\TeX$ in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fork-TeXnique
+# Fork- $\TeX$​nique
 
 A (new) $\LaTeX$ speed-typesetting game. Test yourself in single-player mode, or in multi-player mode in a customizeable lobby with friends. See [credits](#credits)!
 


### PR DESCRIPTION
there's a space after the hyphen because otherwise it doesn't render as latex lmao, and zero width space doesn't seem to work as a separator here. it does however work as a separator AFTER the TeX (before the `nique`)