### PR TITLE
Fixed countdown speeding up when owner buffers multiple starts

### DIFF
--- a/event.go
+++ b/event.go
@@ -135,7 +135,11 @@ func StartGameHandler(event Event, c *Client) error {
 	if *c.lobby.owner != c.name {
 		return fmt.Errorf("only the owner can start the game")
 	}
+	if c.lobby.started {
+		return fmt.Errorf("game has already been started by owner")
+	}
 
+	c.lobby.started = true
 	var broadMessage = StartGameEvent{time.Now().Add(TIME_TO_START_GAME), c.lobby.timeLimit}
 
 	if !DEBUG {

--- a/manager.go
+++ b/manager.go
@@ -74,7 +74,9 @@ type Lobby struct {
 	name      string
 	timeLimit int
 	startTime *int
-	owner     *string
+	// could just check for existence of startTime, but I'm not sure why it's an int pointer instead of a time.Time thing.
+	started bool
+	owner   *string
 
 	// username to (hashed) password
 	userMapping map[string]User
@@ -120,6 +122,7 @@ func NewLobby(ctx context.Context, name string) *Lobby {
 		name:        name,
 		owner:       nil,
 		startTime:   nil,
+		started:     false,
 		clients:     make(ClientList),
 		otps:        NewRetentionMap(ctx, 5*time.Second),
 	}


### PR DESCRIPTION
Funnily enough, I can't seem to reproduce this error, since the game seems to start too quickly now for me to buffer the start button multiple times.

Nevertheless, I've made a change which would ensure only one start game request will go through (in case some frontend was being naughty).